### PR TITLE
Trim parameter values to enhance logging ability

### DIFF
--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/utils/AspectJUtils.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/utils/AspectJUtils.java
@@ -41,12 +41,11 @@ public class AspectJUtils {
 				arguments += "webelement";
 			else if (signatureArg instanceof WebDriver)
 				arguments += "webdriver";
-			else if (signatureArg instanceof String)
-				arguments += ((String) signatureArg).length() > 50
-						? String.format("%s...", ((String) signatureArg).substring(0, 49))
-						: signatureArg;
 			else
-				arguments += signatureArg;
+				arguments += signatureArg.toString().length() > 40
+						? String.format("%s... %s more chars ...", signatureArg.toString().substring(0, 39),
+								signatureArg.toString().length() - 40)
+						: signatureArg.toString();
 		}
 		arguments += ")";
 		return count == 0 ? "" : arguments;


### PR DESCRIPTION
Logging the action, step, test, before and after methods include logging the method parameter values.

Sometimes the values are very huge and decreases the readability of the logs

To avoid this, method parameters should be converted to String using toString() and if the length of the string exceeds 40, then we trim the trailing characters and diasplay the number of characters trimmed