### PR TITLE
Consider null condition for parameter values when logging

### DIFF
--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/utils/AspectJUtils.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/utils/AspectJUtils.java
@@ -37,10 +37,13 @@ public class AspectJUtils {
 		for (Object signatureArg : signatureArgs) {
 			if (++count > 1)
 				arguments += ", ";
+
 			if (signatureArg instanceof WebElement)
 				arguments += "webelement";
 			else if (signatureArg instanceof WebDriver)
 				arguments += "webdriver";
+			else if (signatureArg == null)
+				arguments += "null";
 			else
 				arguments += signatureArg.toString().length() > 40
 						? String.format("%s... %s more chars ...", signatureArg.toString().substring(0, 39),


### PR DESCRIPTION
When printing method argument to logs as execution flow, null values were not taken into account which can result in random null pointer exceptions. This PR fixes it

Related to issue #62 