### PR TITLE
Change atrchitecture of Test Parameters in Test Object to use ITestContext instead of static map

### DIFF
--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
@@ -45,14 +45,37 @@ public abstract class BaseTest {
 		return testObjectMap.get(threadId);
 	}
 
+	/**
+	 * Get the test parameter defined by {@link Parameters} or added to the test
+	 * parameter dynamically by calling
+	 * {@link BaseTest#addTestParameter(String, String)} or
+	 * {@link BaseTest#appendTestParameter(String, String)}
+	 * 
+	 * @param key Name of the parameter
+	 * @return Parameter value
+	 */
 	protected String getTestParameter(String key) {
 		return BaseTest.getTestObject().getTestParameter(key);
 	}
 
+	/**
+	 * Add test parameter. If the parameter with key already exists, the value is
+	 * overwritten
+	 * 
+	 * @param key   Name of the parameter
+	 * @param value Value of the parameter
+	 */
 	protected void addTestParameter(String key, String value) {
 		BaseTest.getTestObject().addTestParameter(key, value);
 	}
 
+	/**
+	 * Append test parameter. this method will get the test parameter with the given
+	 * key and append the provided value as comma seperated String
+	 * 
+	 * @param key   Name of the parameter
+	 * @param value Value of the parameter
+	 */
 	protected void appendTestParameter(String key, String value) {
 		BaseTest.getTestObject().appendTestParameter(key, value);
 	}

--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/BaseTest.java
@@ -37,26 +37,11 @@ public abstract class BaseTest {
 	 * @return {@link TestObject}
 	 */
 	public synchronized static TestObject getTestObject() {
-		return getTestObject("", null);
-	}
-
-	/**
-	 * Get the {@link TestObject} for the current test. If {@link TestObject} is not
-	 * initiated for current Test, a new {@link TestObject}is created
-	 * 
-	 * @param testName       Current TestNG XML test
-	 * @param testParameters Current TestNG XML Test Parameters
-	 * 
-	 * @return {@link TestObject}
-	 */
-	private synchronized static TestObject getTestObject(String testName,
-			Map<String, String> testParameters) {
 		long threadId = ThreadUtils.getThreadId();
 		if (!testObjectMap.containsKey(threadId)) {
-			testObjectMap.put(threadId, new TestObject(testName, testParameters));
 			_logger.info(String.format("Constructing Test Object for threadId %s", threadId));
-		} else
-			_logger.debug(String.format("Reusing Test Object for threadId %s", threadId));
+			testObjectMap.put(threadId, new TestObject());
+		}
 		return testObjectMap.get(threadId);
 	}
 
@@ -129,8 +114,8 @@ public abstract class BaseTest {
 			ITestContext testContext) {
 		System.setProperty("org.uncommons.reportng.escape-output", "false");
 
-		TestObject testObject = BaseTest.getTestObject(testContext.getCurrentXmlTest().getName(),
-				testContext.getCurrentXmlTest().getAllParameters());
+		TestObject testObject = BaseTest.getTestObject();
+		testObject.setTestContext(testContext);
 		testObject.setRepeatMode(repeatMode);
 		testObject.setTestDurationInSeconds(testDurationInSeconds);
 		testObject.setInvocationCount(invocationCount);

--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/TestObject.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/TestObject.java
@@ -31,10 +31,21 @@ public class TestObject {
 
 	private static final Logger _logger = Logger.getLogger(TestObject.class);
 
+	public TestObject(String testName, Map<String, String> testParameters) {
+		setTestName(testName);
+		setTestParameters(testParameters);
+	}
+
 	// Test parameters ----------------------------------------------
 
 	private Map<String, Map<String, String>> testParametersMap = new HashMap<>();
 
+	/**
+	 * Get the Test parameters set at &lt;test&gt; level in TestNG XML file for the
+	 * current TestNG XML test
+	 * 
+	 * @return Test Parameters
+	 */
 	public Map<String, String> getTestParameters() {
 		Map<String, String> testParameters = testParametersMap.get(testName);
 		if (testParameters == null) {
@@ -47,14 +58,14 @@ public class TestObject {
 	/**
 	 * Get Test parameter pertaining to the current {@link Test}
 	 * 
-	 * @param parameter Name of the TestNG {@link Parameters}
+	 * @param key Name of the TestNG {@link Parameters}
 	 * @return Value of the parameter
 	 */
-	public String getTestParameter(String parameter) {
-		String value = getTestParameters().get(parameter);
+	public String getTestParameter(String key) {
+		String value = getTestParameters().get(key);
 		if (value == null)
 			throw new SetupFailedFatalException(
-					String.format("Requested Test Parameter %s not found. Test will exit", parameter));
+					String.format("Requested Test Parameter %s not found. Test will exit", key));
 		return value;
 	}
 
@@ -90,11 +101,19 @@ public class TestObject {
 	/**
 	 * Set all test parameters
 	 * 
+	 * @deprecated Made private. Method will no longer be accessible public in the
+	 *             next version
 	 * @param testParameters {@link Map} of Test Parameters
 	 */
-	public void setTestParameters(Map<String, String> testParameters) {
+	@Deprecated
+	private void setTestParameters(Map<String, String> testParameters) {
+		testParameters = testParameters == null ? new HashMap<>() : testParameters;
+		if (!testParameters.isEmpty())
+			_logger.info("Setting test parameters");
+		else
+			_logger.info("No test parameters obtained");
+		getTestParameters().clear();
 		getTestParameters().putAll(testParameters);
-		_logger.info("Setting test parameters");
 	}
 
 	// Driver Manager -----------------------------------------------
@@ -135,11 +154,11 @@ public class TestObject {
 	 * 
 	 * @param testName Name of the test
 	 */
-	public void setTestName(String testName) {
+	private void setTestName(String testName) {
 		if (!testName.trim().isEmpty())
 			this.testName = testName;
 		else
-			_logger.warn(String.format(" %sBlank testName parameter provided. Will use default test name",
+			_logger.warn(String.format("%s Blank testName parameter provided. Will use default test name",
 					ErrorCode.INVALID_PARAMETER_VALUE.name()));
 		_logger.info(String.format("testName set to %s", getTestName()));
 	}

--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/TestObject.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/core/TestObject.java
@@ -35,6 +35,11 @@ public class TestObject {
 
 	private ITestContext testContext;
 
+	/**
+	 * Get the test parameters from the {@link ITestContext#getCurrentXmlTest()}
+	 * 
+	 * @return {@link Map} of parameter key-value pairs
+	 */
 	public Map<String, String> getTestParameters() {
 		if (testContext == null)
 			throw new SetupFailedFatalException(
@@ -88,6 +93,11 @@ public class TestObject {
 		addTestParameter(key, value);
 	}
 
+	/**
+	 * Set the {@link ITestContext} related to the current XML test being executed.
+	 * 
+	 * @param testContext {@link ITestContext}
+	 */
 	public void setTestContext(ITestContext testContext) {
 		_logger.info(String.format("Setting test context %s", testContext));
 		this.testContext = testContext;

--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/LauncherClientManager.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/LauncherClientManager.java
@@ -151,7 +151,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 * @param duration   Duration of execution of method
 	 */
 	public void logSuccess(String methodName, MethodType methodType, int iteration, long duration) {
-		if (isEnabled && !methodName.toLowerCase().startsWith("automacentInternal"))
+		if (isEnabled && !methodName.toLowerCase().startsWith("automacentinternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logSuccess(methodName, methodType, iteration, duration);
 	}
@@ -166,7 +166,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 * @param duration   Duration of execution of method
 	 */
 	public void logFailure(String methodName, MethodType methodType, int iteration, Throwable e, long duration) {
-		if (isEnabled && !methodName.toLowerCase().startsWith("automacentInternal"))
+		if (isEnabled && !methodName.toLowerCase().startsWith("automacentinternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logFailure(methodName, methodType, iteration, e, duration);
 	}
@@ -199,7 +199,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 * @param methodType {@link MethodType}
 	 */
 	public void logStart(String method, MethodType methodType) {
-		if (isEnabled && !method.toLowerCase().startsWith("automacentInternal"))
+		if (isEnabled && !method.toLowerCase().startsWith("automacentinternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logStart(method, methodType);
 	}
@@ -216,7 +216,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 */
 	public void logEnd(String methodWithArguments, MethodType methodType, TestStatus testStatus, long duration,
 			Throwable t) {
-		if (isEnabled && !methodWithArguments.toLowerCase().startsWith("automacentInternal"))
+		if (isEnabled && !methodWithArguments.toLowerCase().startsWith("automacentinternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logEnd(methodWithArguments, methodType, testStatus, duration, t);
 	}

--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/LauncherClientManager.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/launcher/LauncherClientManager.java
@@ -80,6 +80,7 @@ public class LauncherClientManager implements ILauncherClient {
 			for (String launcherClient : launcherClients)
 				try {
 					Class<?> clazz = Class.forName(launcherClient);
+					// TODO Consider changing the assignable class to interface
 					if (AbstractLauncherClient.class.isAssignableFrom(clazz)) {
 						this.launcherClientMasterMap.put(clazz, new HashMap<>());
 					} else
@@ -150,7 +151,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 * @param duration   Duration of execution of method
 	 */
 	public void logSuccess(String methodName, MethodType methodType, int iteration, long duration) {
-		if (isEnabled && !methodName.toLowerCase().startsWith("automacent"))
+		if (isEnabled && !methodName.toLowerCase().startsWith("automacentInternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logSuccess(methodName, methodType, iteration, duration);
 	}
@@ -165,7 +166,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 * @param duration   Duration of execution of method
 	 */
 	public void logFailure(String methodName, MethodType methodType, int iteration, Throwable e, long duration) {
-		if (isEnabled && !methodName.toLowerCase().startsWith("automacent"))
+		if (isEnabled && !methodName.toLowerCase().startsWith("automacentInternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logFailure(methodName, methodType, iteration, e, duration);
 	}
@@ -198,7 +199,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 * @param methodType {@link MethodType}
 	 */
 	public void logStart(String method, MethodType methodType) {
-		if (isEnabled && !method.toLowerCase().startsWith("automacent"))
+		if (isEnabled && !method.toLowerCase().startsWith("automacentInternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logStart(method, methodType);
 	}
@@ -215,7 +216,7 @@ public class LauncherClientManager implements ILauncherClient {
 	 */
 	public void logEnd(String methodWithArguments, MethodType methodType, TestStatus testStatus, long duration,
 			Throwable t) {
-		if (isEnabled && !methodWithArguments.toLowerCase().startsWith("automacent"))
+		if (isEnabled && !methodWithArguments.toLowerCase().startsWith("automacentInternal"))
 			for (ILauncherClient launcherClient : getLauncherClients())
 				launcherClient.logEnd(methodWithArguments, methodType, testStatus, duration, t);
 	}

--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
@@ -260,6 +260,9 @@ public class AutomacentListener extends TestListenerAdapter
 
 	@Override
 	public void afterInvocation(IInvokedMethod invokedMethod, ITestResult testResult, ITestContext testContext) {
+		String methodName = invokedMethod.getTestMethod().getMethodName();
+		if (!methodName.startsWith("automacentInternal"))
+			testContext.getCurrentXmlTest().setParameters(BaseTest.getTestObject().getTestParameters());
 	}
 
 	/**

--- a/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
+++ b/automacent-fwk-components/automacent-fwk-core/src/main/java/com/automacent/fwk/listeners/AutomacentListener.java
@@ -260,9 +260,6 @@ public class AutomacentListener extends TestListenerAdapter
 
 	@Override
 	public void afterInvocation(IInvokedMethod invokedMethod, ITestResult testResult, ITestContext testContext) {
-		String methodName = invokedMethod.getTestMethod().getMethodName();
-		if (!methodName.startsWith("automacentInternal"))
-			testContext.getCurrentXmlTest().setParameters(BaseTest.getTestObject().getTestParameters());
 	}
 
 	/**


### PR DESCRIPTION
This PR replaces the management of test parameters in the Test Object class from static `map` to `ITestContext`. In this was the changes made to the parameters and retained throughout the `currentXMLTest()`. The Test context is set during execution when setting the framework level parameters through the `automacentInternalSetParameters` method